### PR TITLE
Fix build on windows by patching `dynasm.lua` generated file path separators

### DIFF
--- a/build/generate_fixed_dynasm.zig
+++ b/build/generate_fixed_dynasm.zig
@@ -11,6 +11,7 @@ pub fn main() !void {
     }
 
     const args = try std.process.argsAlloc(alloc);
+    defer std.process.argsFree(alloc, args);
 
     if (args.len != 3) {
         std.debug.print("Usage: `{s} <path-to-dynasm.lua> <path-to-fixed-file-to-create>`\n", .{@typeName(@This())});

--- a/build/generate_fixed_dynasm.zig
+++ b/build/generate_fixed_dynasm.zig
@@ -1,0 +1,51 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    const alloc = gpa.allocator();
+    defer {
+        if (gpa.deinit() != .ok) {
+            std.debug.print("GPA: Leak detected.\n", .{});
+            std.process.exit(1);
+        }
+    }
+
+    const args = try std.process.argsAlloc(alloc);
+
+    if (args.len != 3) {
+        std.debug.print("Usage: `{s} <path-to-dynasm.lua> <path-to-fixed-file-to-create>`\n", .{@typeName(@This())});
+        std.process.exit(1);
+    }
+
+    var input = try std.fs.cwd().openFile(args[1], .{});
+    defer input.close();
+
+    var output = try std.fs.cwd().createFile(args[2], .{});
+    defer output.close();
+
+    var line_buffer: [256 * 1024]u8 = undefined;
+    var reader = input.reader();
+
+    // This seems to be the source of the problem building LuaJIT on windows using Zig.
+    // The `g_fname` is written as windows file paths `C:\Users\Example\...`. The LuaJIT maintainers expect
+    // Windows builds to be run with MSVC (which seems to support these nonstandard paths), but the Zig toolchain
+    // cannot handle it.
+    // https://github.com/LuaJIT/LuaJIT/blob/a4f56a459a588ae768801074b46ba0adcfb49eb1/dynasm/dynasm.lua#L88C5-L88C50
+    const target = (
+        \\wline("#line "..g_lineno..' "'..g_fname..'"')
+    );
+
+    // Instead, we will replace it with the appropriate Lua to normalize the paths back to forward slash separators.
+    const replacement = (
+        \\wline("#line "..g_lineno..' "'..g_fname:gsub("\\", "/")..'"')
+    );
+
+    while (try reader.readUntilDelimiterOrEof(&line_buffer, '\n')) |line| {
+        if (std.mem.indexOf(u8, line, target)) |_| {
+            _ = try output.write(replacement);
+        } else {
+            _ = try output.write(line);
+            _ = try output.write("\n");
+        }
+    }
+}

--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -215,6 +215,9 @@ fn getPathSeparatorFixedDynasm(b: *Build, target: Build.ResolvedTarget, upstream
 
     const wf = b.addWriteFiles();
     _ = wf.addCopyFile(generated, "dynasm/dynasm.lua");
+    _ = wf.addCopyFile(upstream.path("dynasm/dasm_x64.lua"), "dynasm/dasm_x64.lua");
+    _ = wf.addCopyFile(upstream.path("dynasm/dasm_x86.lua"), "dynasm/dasm_x86.lua");
+
     return wf.getDirectory().path(b, "dynasm/dynasm.lua");
 }
 

--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -35,7 +35,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
 
     // Generate the buildvm_arch.h file using minilua
     const dynasm_run = b.addRunArtifact(minilua);
-    dynasm_run.addFileArg(upstream.path("dynasm/dynasm.lua"));
+    dynasm_run.addFileArg(getPathSeparatorFixedDynasm(b, target, upstream));
 
     // TODO: Many more flags to figure out
     if (target.result.cpu.arch.endian() == .little) {
@@ -196,6 +196,26 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     lib.installHeader(luajit_h, "luajit.h");
 
     return lib;
+}
+
+fn getPathSeparatorFixedDynasm(b: *Build, target: Build.ResolvedTarget, upstream: *Build.Dependency) Build.LazyPath {
+    if (target.result.os.tag != .windows) {
+        // Only builds on Windows have this issue, otherwise everything works as advertised.
+        return upstream.path("dynasm/dynasm.lua");
+    }
+
+    const gen_fixed_dynasm = b.addExecutable(.{
+        .target = target,
+        .name = "generate_fixed_dynasm",
+        .root_source_file = b.path("build/generate_fixed_dynasm.zig"),
+    });
+    const run = b.addRunArtifact(gen_fixed_dynasm);
+    run.addFileArg(upstream.path("dynasm/dynasm.lua"));
+    const generated = run.addOutputFileArg("dynasm.lua");
+
+    const wf = b.addWriteFiles();
+    _ = wf.addCopyFile(generated, "dynasm/dynasm.lua");
+    return wf.getDirectory().path(b, "dynasm/dynasm.lua");
 }
 
 const luajit_lib = [_][]const u8{


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/194d5b3e-ac5a-4a85-91f7-40a1fd319650)
