### PR TITLE
Fix cross compilation

### DIFF
--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -30,7 +30,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
         .optimize = .ReleaseSafe,
     });
     minilua.linkLibC();
-    minilua.root_module.sanitize_c = false;
+    minilua.root_module.sanitize_c = .off;
     minilua.addCSourceFile(.{ .file = upstream.path("src/host/minilua.c") });
 
     // Generate the buildvm_arch.h file using minilua
@@ -93,7 +93,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
         .optimize = .ReleaseSafe,
     });
     buildvm.linkLibC();
-    buildvm.root_module.sanitize_c = false;
+    buildvm.root_module.sanitize_c = .off;
 
     // Needs to run after the buildvm_arch.h and luajit.h files are generated
     buildvm.step.dependOn(&dynasm_run.step);
@@ -201,7 +201,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
         .files = &luajit_vm,
     });
 
-    lib.root_module.sanitize_c = false;
+    lib.root_module.sanitize_c = .off;
 
     lib.installHeader(upstream.path("src/lua.h"), "lua.h");
     lib.installHeader(upstream.path("src/lualib.h"), "lualib.h");

--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -26,7 +26,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     // Compile minilua interpreter used at build time to generate files
     const minilua = b.addExecutable(.{
         .name = "minilua",
-        .target = target, // TODO ensure this is the host
+        .target = b.graph.host,
         .optimize = .ReleaseSafe,
     });
     minilua.linkLibC();
@@ -74,10 +74,22 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     genversion_run.addFileArg(b.path("build/luajit_relver.txt"));
     const luajit_h = genversion_run.addOutputFileArg("luajit.h");
 
+    // LuaJIT doesn't cross compile very well...
+    // We need to execute buildvm on the target architecture, but we can use QEMU if available
+    // However, we can't use the target directly since it may not be compatible (i.e. GNU on NixOS)
+    const buildvm_target = blk: {
+        if (target.result.cpu.arch != @import("builtin").target.cpu.arch) {
+            var query = target.query;
+            query.abi = .default(target.result.cpu.arch, @import("builtin").os.tag);
+            break :blk b.resolveTargetQuery(query);
+        }
+        break :blk target;
+    };
+
     // Compile the buildvm executable used to generate other files
     const buildvm = b.addExecutable(.{
         .name = "buildvm",
-        .target = target, // TODO ensure this is the host
+        .target = buildvm_target,
         .optimize = .ReleaseSafe,
     });
     buildvm.linkLibC();
@@ -169,6 +181,10 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     lib.linkSystemLibrary("unwind");
     lib.root_module.unwind_tables = .sync;
 
+    // Zig's compiler_rt does not provide this architecture-specific function.
+    // Thankfully, Clang provides a builtin to accomplish the same thing.
+    lib.root_module.addCMacro("__clear_cache", "__builtin___clear_cache");
+
     lib.addIncludePath(upstream.path("src"));
     lib.addIncludePath(luajit_h.dirname());
     lib.addIncludePath(bcdef_header.dirname());
@@ -203,7 +219,7 @@ fn getPathSeparatorFixedDynasm(b: *Build, target: Build.ResolvedTarget, upstream
     }
 
     const gen_fixed_dynasm = b.addExecutable(.{
-        .target = target,
+        .target = b.graph.host,
         .name = "generate_fixed_dynasm",
         .root_source_file = b.path("build/generate_fixed_dynasm.zig"),
     });


### PR DESCRIPTION
Fixed cross-compilation. It turns out that LuaJIT doesn't support cross-compilation and `buildvm` must be ran on the target architecture. Thankfully Zig integrates smoothly with QEMU. There was an additional complication when the target's architecture is compatible with the host, but the target ABI isn't. The most obvious case is when the target's ABI is GNU and the host is NixOS. The cleanest solution I could come up with was overriding the ABI for `buildvm` from the target's ABI to the one mostly likely to be statically linkable. I'm sure there's a more correct solution, but this seems to work plenty fine in every configuration I've tested.

Also updated to new `sanitize_c` enum. I put this in a separate commit in case you wanted to cherry-pick.