### PR TITLE
Fix x86-32 windows cross-compilation

### DIFF
--- a/build/luajit.zig
+++ b/build/luajit.zig
@@ -78,7 +78,7 @@ pub fn configure(b: *Build, target: Build.ResolvedTarget, optimize: std.builtin.
     const buildvm_target = blk: {
         if (target.result.cpu.arch != @import("builtin").target.cpu.arch) {
             var query = target.query;
-            query.abi = .default(target.result.cpu.arch, @import("builtin").os.tag);
+            query.abi = .default(target.result.cpu.arch, target.result.os.tag);
             break :blk b.resolveTargetQuery(query);
         }
         break :blk target;


### PR DESCRIPTION
This fixed cross-compilation for x86-32 windows on my system ***BUT*** I'm not sure about any further implications behind this change.

## Output without the change

```
$ zig build -Dtarget=x86-windows-gnu

install
└─ install simple-repl
   └─ compile exe simple-repl Debug x86-windows-gnu
      └─ translate-c
         └─ install lua
            └─ compile lib lua Debug x86-windows-gnu
               └─ run exe buildvm (lj_recdef.h)
                  └─ compile exe buildvm ReleaseSafe x86-windows-musl failure
error: error: unable to provide libc for target 'x86-windows.win10...win11_dt-musl'
info: zig can provide libc for related target x86-windows-gnu

...
```